### PR TITLE
Sanitize button text (only allow break tags)

### DIFF
--- a/inc/class-admin.php
+++ b/inc/class-admin.php
@@ -82,7 +82,9 @@ class Admin {
 				'server_path' => trailingslashit( trim( $_POST['server_path'] ) ),
 				'provision' => in_array( $_POST['provision'], [ 'refuse', 'create' ], true ) ? $_POST['provision'] : 'refuse',
 				'email_domain' => ltrim( trim( $_POST['email_domain'] ), '@' ),
-				'button_text' => isset( $_POST['button_text'] ) ? trim( wp_unslash( wp_kses( $_POST['button_text'], [ 'br' => [] ] ) ) ) : $fallback['button_text'],
+				'button_text' => isset( $_POST['button_text'] ) ? trim( wp_unslash( wp_kses( $_POST['button_text'], [
+					'br' => [],
+				] ) ) ) : $fallback['button_text'],
 				'bypass' => ! empty( $_POST['bypass'] ) ? 1 : 0,
 				'forced_redirection' => ! empty( $_POST['forced_redirection'] ) ? 1 : 0,
 			];

--- a/inc/class-admin.php
+++ b/inc/class-admin.php
@@ -82,7 +82,7 @@ class Admin {
 				'server_path' => trailingslashit( trim( $_POST['server_path'] ) ),
 				'provision' => in_array( $_POST['provision'], [ 'refuse', 'create' ], true ) ? $_POST['provision'] : 'refuse',
 				'email_domain' => ltrim( trim( $_POST['email_domain'] ), '@' ),
-				'button_text' => isset( $_POST['button_text'] ) ? trim( wp_unslash( $_POST['button_text'] ) ) : $fallback['button_text'],
+				'button_text' => isset( $_POST['button_text'] ) ? trim( wp_unslash( wp_kses( $_POST['button_text'], [ 'br' => [] ] ) ) ) : $fallback['button_text'],
 				'bypass' => ! empty( $_POST['bypass'] ) ? 1 : 0,
 				'forced_redirection' => ! empty( $_POST['forced_redirection'] ) ? 1 : 0,
 			];

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -49,7 +49,7 @@ class AdminTest extends \WP_UnitTestCase {
 			'server_path' => '/foo/bar',
 			'provision' => 'create',
 			'email_domain' => '@pressbooks.test',
-			'button_text' => 'SSO',
+			'button_text' => 'Connect via<br>Some SSO Provider<script src="http://evil-script.com/script.js"></script>',
 			'bypass' => '1',
 			'forced_redirection' => '1',
 		];
@@ -62,7 +62,7 @@ class AdminTest extends \WP_UnitTestCase {
 		$this->assertEquals( $options['server_path'], '/foo/bar/' );
 		$this->assertEquals( $options['provision'], 'create' );
 		$this->assertEquals( $options['email_domain'], 'pressbooks.test' );
-		$this->assertEquals( $options['button_text'], 'SSO' );
+		$this->assertEquals( $options['button_text'], 'Connect via<br>Some SSO Provider' );
 		$this->assertEquals( $options['bypass'], 1 );
 		$this->assertEquals( $options['forced_redirection'], 1 );
 	}


### PR DESCRIPTION
This PR uses `wp_kses()` to ensure that only `<br>` tags are allowed in the button text field.