### PR TITLE
Bump requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Pressbooks CAS Single Sign-On 
 **Contributors:** conner_bw, greatislander  
 **Tags:** pressbooks, sso, cas  
-**Requires at least:** 5.0.3  
-**Tested up to:** 5.0.3  
-**Stable tag:** 1.1.2  
+**Requires at least:** 5.1.0  
+**Tested up to:** 5.1.0  
+**Stable tag:** 1.2.0  
 **License:** GPLv3 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-3.0.html  
 
@@ -56,6 +56,12 @@ Because this plugin uses the fabulous [apereo/phpCAS](https://github.com/apereo/
 
 ## Changelog 
 
+### 1.2.0
+ * Refactor code to respect Pressbooks coding standards 1.0.0
+ * Fix an issue with GitHub updater not always working
+ * Update dependencies to latest versions
+
+
 ### 1.1.2 
  * Update README
  * Update apereo/phpCAS to 2aaad20
@@ -99,5 +105,5 @@ Because this plugin uses the fabulous [apereo/phpCAS](https://github.com/apereo/
 ## Upgrade Notice 
 
 
-### 1.1.2 
-* Pressbooks CAS Single Sign-On requires Pressbooks >= 5.6.5 and WordPress >= 5.0.3
+### 1.2.0 
+* Pressbooks CAS Single Sign-On requires Pressbooks >= 5.7.0 and WordPress >= 5.1.0

--- a/pressbooks-cas-sso.php
+++ b/pressbooks-cas-sso.php
@@ -3,11 +3,11 @@
 Plugin Name: Pressbooks CAS Single Sign-On
 Plugin URI: https://pressbooks.org
 Description: CAS Single Sign-On integration for Pressbooks.
-Version: 1.1.2
+Version: 1.2.0
 Author: Pressbooks (Book Oven Inc.)
 Author URI: https://pressbooks.org
 Requires PHP: 7.1
-Pressbooks tested up to: 5.6.5
+Pressbooks tested up to: 5.7.0
 Text Domain: pressbooks-cas-sso
 License: GPL v3 or later
 Network: True

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Pressbooks CAS Single Sign-On ===
 Contributors: conner_bw, greatislander
 Tags: pressbooks, sso, cas
-Requires at least: 5.0.3
-Tested up to: 5.0.3
-Stable tag: 1.1.2
+Requires at least: 5.1.0
+Tested up to: 5.1.0
+Stable tag: 1.2.0
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -49,6 +49,11 @@ Because this plugin uses the fabulous [apereo/phpCAS](https://github.com/apereo/
 ![Pressbooks CAS Administration.](screenshot-1.png)
 
 == Changelog ==
+= 1.2.0=
+ * Refactor code to respect Pressbooks coding standards 1.0.0
+ * Fix an issue with GitHub updater not always working
+ * Update dependencies to latest versions
+
 = 1.1.2 =
  * Update README
  * Update apereo/phpCAS to 2aaad20
@@ -83,5 +88,5 @@ Because this plugin uses the fabulous [apereo/phpCAS](https://github.com/apereo/
 
 == Upgrade Notice ==
 
-= 1.1.2 =
-* Pressbooks CAS Single Sign-On requires Pressbooks >= 5.6.5 and WordPress >= 5.0.3
+= 1.2.0 =
+* Pressbooks CAS Single Sign-On requires Pressbooks >= 5.7.0 and WordPress >= 5.1.0


### PR DESCRIPTION
Pressbooks CAS Single Sign-On requires Pressbooks >= 5.7.0 and WordPress >= 5.1.0