### PR TITLE
chore: add Dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `package-lock.json` files in the root directory
+    directory: "/"
+    # Check for updates monthly
+    schedule:
+      interval: "monthly"
+    allow:
+      # Allow direct updates only (for packages named in package.json)
+      - dependency-type: "direct"
+    # Allow up to 10 open pull requests for npm dependencies
+    open-pull-requests-limit: 10
+
+  # Maintain dependencies for Composer
+  - package-ecosystem: "composer"
+    # Look for `composer.json` and `composer.lock` files in the root directory
+    directory: "/"
+    # Check for updates monthly
+    schedule:
+      interval: "monthly"
+    allow:
+      # Allow direct updates only (for packages named in composer.json)
+      - dependency-type: "direct"
+    # Allow up to 10 open pull requests for composer dependencies
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This PR adds a configuration file for Dependabot, specifying that only direct (top-level) dependencies should be checked for updates.

See: pressbooks/pressbooks#2236.