### PR TITLE
ci: use wp-cli i18n command instead of pb-cli

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup PHP with tools
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.3'
+        php-version: '7.4'
         tools: composer, wp-cli/wp-cli-bundle
     - name: Update POT file
       run: wp i18n make-pot . languages/pressbooks-cas-sso.pot --domain=pressbooks-cas-sso --slug=pressbooks-cas-sso --package-name="Pressbooks CAS Single Sign-On" --headers="{\"Report-Msgid-Bugs-To\":\"https://github.com/pressbooks/pressbooks-cas-sso/issues\"}"

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -19,16 +19,17 @@ jobs:
         php-version: '7.3'
         tools: composer, wp-cli
     - name: Install dependencies
-      run: |
-        wp package install wp-cli/i18n-command:2.2.8
-        cd /home/runner/.wp-cli/packages/
-        composer config repositories.wp-cli '{"type": "composer","url": "https://wp-cli.org/package-index/","canonical": false}'
-        cd ./
-        wp package install pressbooks/pb-cli:2.1.0
+      run: wp package install wp-cli/i18n-command
     - name: Update POT file
-      run: wp pb make-pot . languages/pressbooks-cas-sso.pot --require=vendor/autoload.php --domain=pressbooks-cas-sso --slug=pressbooks-cas-sso --package-name="Pressbooks CAS SSO" --headers="{\"Report-Msgid-Bugs-To\":\"https://github.com/pressbooks/pressbooks-cas-sso/issues\"}"
-    - name: Commit updated POT file
-      uses: stefanzweifel/git-auto-commit-action@v4.13.1
+      run: wp i18n make-pot . languages/pressbooks-cas-sso.pot --domain=pressbooks-cas-sso --slug=pressbooks-cas-sso --package-name="Pressbooks CAS SSO" --headers="{\"Report-Msgid-Bugs-To\":\"https://github.com/pressbooks/pressbooks-cas-sso/issues\"}"
+    # Remove this step once you are satisfied with the results; alternatively, you can leave it in place and remove
+    # the commented out step that follows.
+    - name: Open PR with changes
+      uses: peter-evans/create-pull-request@v4
       with:
-        commit_message: 'chore(l10n): update languages/pressbooks-cas-sso.pot'
-        file_pattern: '*.pot'
+        title: 'chore(l10n): update languages/pressbooks-cas-sso.pot'
+    # - name: Commit updated POT file
+    #   uses: stefanzweifel/git-auto-commit-action@v4.13.1
+    #   with:
+    #     commit_message: 'chore(l10n): update languages/pressbooks-cas-sso.pot'
+    #     file_pattern: '*.pot'

--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -17,11 +17,9 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '7.3'
-        tools: composer, wp-cli
-    - name: Install dependencies
-      run: wp package install wp-cli/i18n-command
+        tools: composer, wp-cli/wp-cli-bundle
     - name: Update POT file
-      run: wp i18n make-pot . languages/pressbooks-cas-sso.pot --domain=pressbooks-cas-sso --slug=pressbooks-cas-sso --package-name="Pressbooks CAS SSO" --headers="{\"Report-Msgid-Bugs-To\":\"https://github.com/pressbooks/pressbooks-cas-sso/issues\"}"
+      run: wp i18n make-pot . languages/pressbooks-cas-sso.pot --domain=pressbooks-cas-sso --slug=pressbooks-cas-sso --package-name="Pressbooks CAS Single Sign-On" --headers="{\"Report-Msgid-Bugs-To\":\"https://github.com/pressbooks/pressbooks-cas-sso/issues\"}"
     # Remove this step once you are satisfied with the results; alternatively, you can leave it in place and remove
     # the commented out step that follows.
     - name: Open PR with changes

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup PHP with tools
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.3'
+        php-version: '7.4'
         tools: composer, wp-cli
     - name: Install dependencies
       run: wp package install wp-cli/i18n-command

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -30,7 +30,7 @@ jobs:
       uses: peter-evans/create-pull-request@v4
       with:
         title: 'chore(l10n): update translations'
-    # - name: Commit updated POT file
+    # - name: Commit updated translation files
     #   uses: stefanzweifel/git-auto-commit-action@v4.13.1
     #   with:
     #     commit_message: 'chore(l10n): update translations'

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -19,9 +19,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '7.3'
-        tools: composer, wp-cli
-    - name: Install dependencies
-      run: wp package install wp-cli/i18n-command
+        tools: composer, wp-cli/wp-cli-bundle
     - name: Generate MO files
       run: wp i18n make-mo languages
     # Remove this step once you are satisfied with the results; alternatively, you can leave it in place and remove

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -15,12 +15,23 @@ jobs:
       run: tx pull --all --force --minimum-perc=25
       env:
         TX_TOKEN: ${{ secrets.TX_TOKEN }}
-    - name: Install xgettext
-      run: sudo apt-get install -y gettext
-    - name: Generate MO files
-      run: for file in languages/*.po ; do msgfmt $file -o `echo $file | sed 's/\(.*\.\)po/\1mo/'` ; done
-    - name: Commit updated translation files
-      uses: stefanzweifel/git-auto-commit-action@v4.13.1
+    - name: Setup PHP with tools
+      uses: shivammathur/setup-php@v2
       with:
-        commit_message: 'chore(l10n): update translations'
-        file_pattern: '*.mo *.po'
+        php-version: '7.3'
+        tools: composer, wp-cli
+    - name: Install dependencies
+      run: wp package install wp-cli/i18n-command
+    - name: Generate MO files
+      run: wp i18n make-mo languages
+    # Remove this step once you are satisfied with the results; alternatively, you can leave it in place and remove
+    # the commented out step that follows.
+    - name: Open PR with changes
+      uses: peter-evans/create-pull-request@v4
+      with:
+        title: 'chore(l10n): update translations'
+    # - name: Commit updated POT file
+    #   uses: stefanzweifel/git-auto-commit-action@v4.13.1
+    #   with:
+    #     commit_message: 'chore(l10n): update translations'
+    #     file_pattern: '*.mo'


### PR DESCRIPTION
Partial resolution to https://github.com/pressbooks/private/issues/910. In addition to replacing the `wp pb make-pot` command with `wp i18n make-pot`, this PR also replaces the `update-translations.yml` workflow's use of gettext with the `wp i18n make-mo` command, which does the same thing.

I've commented out the step which autocommits changes. Instead, when these workflows run if they result in any changed files, they will open a PR. Devs can merge if it looks good. In future, you may wish to switch back to autocommit.