### PR TITLE
feat: use WordPress plugin dependency feature

### DIFF
--- a/pressbooks-cas-sso.php
+++ b/pressbooks-cas-sso.php
@@ -2,6 +2,8 @@
 /**
  * Plugin Name:         Pressbooks CAS Single Sign-On
  * Plugin URI:          https://pressbooks.org
+ * Requires at least:   6.5
+ * Requires Plugins:    pressbooks
  * GitHub Plugin URI:   pressbooks/pressbooks-cas-sso
  * Release Asset:       true
  * Description:         CAS Single Sign-On integration for Pressbooks.
@@ -14,20 +16,6 @@
  * Text Domain:         pressbooks-cas-sso
  * Network: True
  */
-
-// -------------------------------------------------------------------------------------------------------------------
-// Check requirements
-// -------------------------------------------------------------------------------------------------------------------
-if ( ! function_exists( 'pb_meets_minimum_requirements' ) && ! @include_once( WP_PLUGIN_DIR . '/pressbooks/compatibility.php' ) ) { // @codingStandardsIgnoreLine
-	add_action(
-		'admin_notices', function () {
-			echo '<div id="message" role="alert" class="error fade"><p>' . __( 'Cannot find Pressbooks install.', 'pressbooks-cas-sso' ) . '</p></div>';
-		}
-	);
-	return;
-} elseif ( ! pb_meets_minimum_requirements() ) {
-	return;
-}
 
 // -------------------------------------------------------------------------------------------------------------------
 // Class autoloader


### PR DESCRIPTION
WordPress 6.5 (coming Tuesday) introduces [plugin dependencies](https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/).

This means we can remove the `pb_meets_minimum_requirements` check.